### PR TITLE
Add GitHub storage for quotes

### DIFF
--- a/FQ Project Testing v1.2.1
+++ b/FQ Project Testing v1.2.1
@@ -210,6 +210,14 @@
             <label for="costPerTrailer">Cost Per Trailer ($):</label>
             <input type="text" id="costPerTrailer" placeholder="Enter cost per trailer">
 
+            <hr>
+            <label for="githubRepo">GitHub Repo (owner/repo):</label>
+            <input type="text" id="githubRepo" placeholder="user/repo">
+
+            <label for="githubToken">GitHub Token:</label>
+            <input type="text" id="githubToken" placeholder="Personal Access Token">
+            <button type="button" onclick="storeGitHubSettings()">Save GitHub Settings</button>
+
             <button onclick="calculateQuote()">Calculate Quote</button>
         </div>
         <div class="output-container">
@@ -223,6 +231,115 @@
     <script>
         let highlightedData = "";
         let currentFuelProgram = "";
+        let db;
+
+        function initDatabase() {
+            const request = indexedDB.open('FreightQuotes', 1);
+
+            request.onerror = function(event) {
+                console.error('Database error:', event.target.error);
+            };
+
+            request.onsuccess = function(event) {
+                db = event.target.result;
+            };
+
+            request.onupgradeneeded = function(event) {
+                db = event.target.result;
+                if (!db.objectStoreNames.contains('quotes')) {
+                    db.createObjectStore('quotes', { keyPath: 'id', autoIncrement: true });
+                }
+            };
+        }
+
+        function saveQuoteToDB(data) {
+            if (!db) {
+                console.warn('Database not initialized');
+                return;
+            }
+            const tx = db.transaction('quotes', 'readwrite');
+            tx.objectStore('quotes').add(data);
+            tx.oncomplete = function() {
+                console.log('Quote saved');
+            };
+            tx.onerror = function(event) {
+                console.error('Failed to save quote:', event.target.error);
+            };
+        }
+
+        const githubConfig = {
+            repo: '',
+            branch: 'gh-pages',
+            file: 'quotes.json',
+            token: ''
+        };
+
+        function loadGitHubSettings() {
+            githubConfig.repo = localStorage.getItem('githubRepo') || '';
+            githubConfig.token = localStorage.getItem('githubToken') || '';
+            const repoInput = document.getElementById('githubRepo');
+            const tokenInput = document.getElementById('githubToken');
+            if (repoInput) repoInput.value = githubConfig.repo;
+            if (tokenInput) tokenInput.value = githubConfig.token;
+        }
+
+        function storeGitHubSettings() {
+            githubConfig.repo = document.getElementById('githubRepo').value;
+            githubConfig.token = document.getElementById('githubToken').value;
+            localStorage.setItem('githubRepo', githubConfig.repo);
+            localStorage.setItem('githubToken', githubConfig.token);
+            alert('GitHub settings saved locally');
+        }
+
+        async function saveQuoteToGitHub(record) {
+            if (!githubConfig.repo || !githubConfig.token) {
+                console.log('GitHub settings missing, skipping GitHub save');
+                return;
+            }
+            const parts = githubConfig.repo.split('/');
+            if (parts.length !== 2) {
+                console.error('Invalid repo format');
+                return;
+            }
+            const [owner, repo] = parts;
+            const apiBase = `https://api.github.com/repos/${owner}/${repo}/contents/${githubConfig.file}`;
+            let quotes = [];
+            let sha;
+            try {
+                const resp = await fetch(`${apiBase}?ref=${githubConfig.branch}`, {
+                    headers: { Authorization: 'token ' + githubConfig.token }
+                });
+                if (resp.ok) {
+                    const data = await resp.json();
+                    sha = data.sha;
+                    const content = atob(data.content.replace(/\n/g, ''));
+                    quotes = JSON.parse(content);
+                }
+            } catch (err) {
+                console.warn('Could not read existing quotes from GitHub');
+            }
+            quotes.push(record);
+            const newContent = btoa(JSON.stringify(quotes, null, 2));
+            const body = {
+                message: 'Add quote',
+                content: newContent,
+                branch: githubConfig.branch
+            };
+            if (sha) body.sha = sha;
+            const putResp = await fetch(apiBase, {
+                method: 'PUT',
+                headers: {
+                    Authorization: 'token ' + githubConfig.token,
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(body)
+            });
+            if (!putResp.ok) {
+                console.error('Failed to save quote to GitHub', await putResp.text());
+            } else {
+                console.log('Quote saved to GitHub');
+            }
+        }
 
         function generateProfitMarginOptions() {
             const profitMarginSelect = document.getElementById('profitMargin');
@@ -237,6 +354,8 @@
 
         window.onload = function() {
             generateProfitMarginOptions();
+            initDatabase();
+            loadGitHubSettings();
         };
 
         function copyToClipboard() {
@@ -418,6 +537,30 @@ Trailer Adder Total: $${trailerAdder.toFixed(2)}`;
                 highlightedData += `
 
 This quote is valid for 7 days from issuance and subject to our standard Terms and Conditions, available upon request. Rates provided exclude detention, layovers, taxes, or additional services unless specifically indicated. Shipments must comply with stated weights, dimensions, and standard loading/unloading procedures; additional charges may apply for non-standard conditions or unforeseen circumstances. Acceptance of this quotation implies acknowledgment and acceptance of all conditions stated herein.`;
+
+                const quoteRecord = {
+                    timestamp: new Date().toISOString(),
+                    customer,
+                    startZip,
+                    endZip,
+                    commodity,
+                    fuelProgram,
+                    lineType,
+                    tripType,
+                    loadType,
+                    distance: parseFloat(distance.toFixed(2)),
+                    fuelPrice: fuelPriceNumber,
+                    finalQuote: parseFloat(finalQuote.toFixed(2)),
+                    costPerMile: parseFloat(costPerMile.toFixed(2)),
+                    tollCharges,
+                    miscCharges,
+                    trailerType,
+                    numTrailers,
+                    costPerTrailer,
+                    trailerAdder: parseFloat(trailerAdder.toFixed(2))
+                };
+                saveQuoteToDB(quoteRecord);
+                saveQuoteToGitHub(quoteRecord);
 
             } catch (error) {
                 console.error("Error calculating quote:", error);

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ The application is distributed as an HTML file named `FQ Project Testing v1.2.1`
 1. Clone this repository.
 2. Open `FQ Project Testing v1.2.1` in your web browser.
 3. Fill out the form with shipment details such as origin, destination, trailer type, and cost.
-4. Press **Calculate Quote** to compute the estimate.
+4. Press **Calculate Quote** to compute the estimate. Each calculation is stored in your browser using IndexedDB so you can retrieve quote history later if needed.
 5. Use **Copy to Clipboard** to copy the quote summary.
 
 The app retrieves current fuel prices from the EIA API and factors them into your quote.
+
+### GitHub Storage
+
+If you provide a GitHub personal access token and repository name in the form, the app will also update a `quotes.json` file on that repo's `gh-pages` branch whenever a quote is calculated. Your token and repo are saved locally in your browser.


### PR DESCRIPTION
## Summary
- allow saving quote history to GitHub via `quotes.json`
- add inputs for GitHub repo and token
- document optional GitHub integration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68470f9dd934832bb03e1e2014af131e